### PR TITLE
Develop dotnet6

### DIFF
--- a/.github/workflows/build-usb64-linux.yml
+++ b/.github/workflows/build-usb64-linux.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ 'netcoreapp3.1', 'net5.0' ]
+        dotnet: [ 'netcoreapp3.1', 'net5.0', 'net6.0' ]
     name: Build ${{ matrix.dotnet }} usb64 Linux
     steps:
       - uses: actions/checkout@v2
@@ -16,10 +16,14 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Setup .NET Core 5.0
+                - name: Setup .NET Core 5.0
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+      - name: Setup .NET Core 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
         
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/build-usb64-linux.yml
+++ b/.github/workflows/build-usb64-linux.yml
@@ -35,7 +35,8 @@ jobs:
         run: dotnet build ./usb64/usb64.sln --configuration Release --no-restore --framework ${{ matrix.dotnet }}
   
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: usb64-${{ matrix.dotnet }}-app-linux
-          path: ${{ github.workspace }}/usb64/usb64/bin/Release/${{ matrix.dotnet }}/usb64.dll
+          path: |
+            ${{ github.workspace }}/usb64/usb64/bin/Release/${{ matrix.dotnet }}/usb64.dll

--- a/.github/workflows/build-usb64-linux.yml
+++ b/.github/workflows/build-usb64-linux.yml
@@ -33,8 +33,6 @@ jobs:
   
       - name: Build App
         run: dotnet build ./usb64/usb64.sln --configuration Release --no-restore --framework ${{ matrix.dotnet }}
-      #- name: Test App
-      #  run: dotnet test
   
       - name: Upload Artifact
         uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/build-usb64-linux.yml
+++ b/.github/workflows/build-usb64-linux.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-                - name: Setup .NET Core 5.0
+      - name: Setup .NET Core 5.0
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x

--- a/.github/workflows/build-usb64-windows.yml
+++ b/.github/workflows/build-usb64-windows.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet: [ 'net40', 'net45', 'netcoreapp3.1', 'net5.0' ]
+        dotnet: [ 'net40', 'net45', 'netcoreapp3.1', 'net5.0', 'net6.0' ]
     name: Build ${{ matrix.dotnet }} usb64 App
     steps:
       - uses: actions/checkout@v2
         name: Checkout Code
-     
+
       - name: Setup .NET Core 3.1
         uses: actions/setup-dotnet@v1
         with:
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
 
       # - name: Setup MSBuild Path
       #   uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/build-usb64-windows.yml
+++ b/.github/workflows/build-usb64-windows.yml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet build ./usb64/usb64.sln --configuration Release --no-restore --framework ${{ matrix.dotnet }}
   
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: usb64-${{ matrix.dotnet }}-app-windows
           path: |

--- a/.github/workflows/build-usb64-windows.yml
+++ b/.github/workflows/build-usb64-windows.yml
@@ -24,9 +24,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
-
-      # - name: Setup MSBuild Path
-      #   uses: microsoft/setup-msbuild@v1.0.2
         
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
@@ -34,16 +31,13 @@ jobs:
       - name: Restore NuGet Packages
         run: nuget restore ./usb64/usb64.sln
   
-      # - name: Build App
-      #   run: msbuild ./usb64/usb64.sln /p:Configuration=Release /p:framework=${{ matrix.dotnet }}
-
       - name: Build App
         run: dotnet build ./usb64/usb64.sln --configuration Release --no-restore --framework ${{ matrix.dotnet }}
-      #- name: Test App
-      #  run: dotnet test
   
       - name: Upload Artifact
         uses: actions/upload-artifact@v1.0.0
         with:
           name: usb64-${{ matrix.dotnet }}-app-windows
-          path: ${{ github.workspace }}\usb64\usb64\bin\Release\${{ matrix.dotnet }}\usb64.exe
+          path: |
+            ${{ github.workspace }}\usb64\usb64\bin\Release\${{ matrix.dotnet }}\usb64.exe
+            ${{ github.workspace }}\usb64\usb64\bin\Release\${{ matrix.dotnet }}\usb64.dll

--- a/usb64/usb64/usb64.csproj
+++ b/usb64/usb64/usb64.csproj
@@ -2,17 +2,20 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net5.0;net45;net40</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net5.0;net6.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Authors>Krikzz / NetworkFusion</Authors>
     <Company>Krikzz</Company>
-    <Copyright>Copyright © Krikzz, NetworkFusion 2020-2021</Copyright>
+    <Copyright>Copyright © Krikzz, NetworkFusion 2020-2022</Copyright>
     <PackageProjectUrl>https://github.com/krikzz/ED64/</PackageProjectUrl>
     <AssemblyVersion>2.0.0.3</AssemblyVersion>
     <FileVersion>2.0.0.3</FileVersion>
     <RootNamespace>ed64usb</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="System.IO.Ports" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="System.IO.Ports" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Adds a `.net6` build for default compatibility with Windows 11 and linux.

## Related Issue
N/A

## Motivation and Context
Makes it easier to use loader out the box.

## How Has This Been Tested?
Tested with local build.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11439699/150849675-7bdf14c8-385a-4875-8768-ecd3654d392c.png)
