### PR TITLE
Fixed issues with 0xff padding check and removal

### DIFF
--- a/usb64/usb64/CommandProcessor.cs
+++ b/usb64/usb64/CommandProcessor.cs
@@ -204,18 +204,20 @@ namespace ed64usb
 
                         //Loading a ROM generated with 'makemask' over USB less than 1MB in size doesn't seem to like `0xff` padding. 
                         //Lets remove them as a workaround!
-                        for (int i = romBytes.Count; i > 0; i--) //cycle backwards through the byte array
+                        if (romBytes.Count < 3000000)
                         {
-                            if (romBytes[i] == 0xff)
+                            for (int i = romBytes.Count - 1; i > 0; i--) //cycle backwards through the byte array
                             {
-                                romBytes.RemoveAt(i);
-                            }
-                            else //break on first chance.
-                            {
-                                return;
+                                if (romBytes[i] == 0xff)
+                                {
+                                    romBytes.RemoveAt(i);
+                                }
+                                else //break on first chance.
+                                {
+                                    break;
+                                }
                             }
                         }
-
                         RomWrite(romBytes.ToArray(), baseAddress);
                     }
                 }


### PR DESCRIPTION
## Description
This PR fixes an issue that prevents ROMs from loading to EverDrive x7 via USB.

## Related Issue
(https://github.com/krikzz/ED64/issues/23)

## Motivation and Context
Could not load any ROMs, failed on Index out of Range error. Fixing this error revealed that a loop was returning a method when it should have been breaking the loop. After fixing this error most ROMs (padded and unpadded) worked, but Super Mario 64 did not. Added a condition to only check for padding if ROM is below 3 MB in order to hopefully exclude all retail ROMs from breaking.

## How Has This Been Tested?
Loaded padded and unpadded roms, both homebrew and retail successfully.

## Screenshots (if appropriate):