### PR TITLE
Add stream-safe serial port connection, remove .NET 5 dependency 

### DIFF
--- a/usb64/usb64/SafeSerialPort.cs
+++ b/usb64/usb64/SafeSerialPort.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Ports;
+using System.Text;
+
+namespace ed64usb
+{
+    /// <summary>
+    /// SafeSerialPort solves the issue of streams being unable to be closed 
+    /// following a sudden disconnect to a port. 
+    /// </summary>
+    public class SafeSerialPort : SerialPort
+    {
+        private Stream baseStream;
+
+        public SafeSerialPort()
+            : base() { }
+        public SafeSerialPort(string portName)
+            : base(portName) { }
+
+        public new void Open()
+        {
+            base.Open();
+            baseStream = BaseStream;
+            GC.SuppressFinalize(BaseStream);
+        }
+
+        public new void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (base.Container != null))
+            {
+                base.Container.Dispose();
+            }
+            try
+            {
+                if (baseStream.CanRead)
+                {
+                    baseStream.Close();
+                    GC.ReRegisterForFinalize(baseStream);
+                }
+            }
+            catch { } // ignore exception - bug with USB - serial adapters.
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/usb64/usb64/UsbInterface.cs
+++ b/usb64/usb64/UsbInterface.cs
@@ -6,7 +6,7 @@ namespace ed64usb
     public static class UsbInterface
     {
 
-        private static SerialPort port;
+        private static SafeSerialPort port;
         public static int ProgressBarTimerInterval { get; set; }
         public static int ProgressBarTimerCounter { get; set; }
 
@@ -92,7 +92,7 @@ namespace ed64usb
 
                 try
                 {
-                    port = new SerialPort(p);
+                    port = new SafeSerialPort(p);
                     port.Open();
                     port.ReadTimeout = 200;
                     port.WriteTimeout = 200;

--- a/usb64/usb64/usb64.csproj
+++ b/usb64/usb64/usb64.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net5.0;net45;net40</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net45;net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
     <Authors>Krikzz / NetworkFusion</Authors>
     <Company>Krikzz</Company>
     <Copyright>Copyright © Krikzz, NetworkFusion 2020-2021</Copyright>


### PR DESCRIPTION
## Description
Added in safety for serial port to safely close the stream upon sudden disconnect and prevent memory leaks. 
There's an additional commit to remove a .net dependency that I did not see a need for- I think at the time I didn't have the new .Net experience and didn't find it necessary to be in this codebase since this requirement caused a framework error for me. 
Feel free to merge this code if it is helpful, or you may request I can remove the target framework commit and resubmit this pull request.